### PR TITLE
Fix: acceso correcto a los históricos del BCV

### DIFF
--- a/app/controllers/history_data_controller.py
+++ b/app/controllers/history_data_controller.py
@@ -11,6 +11,7 @@ from app.database.models.bcv_sql_model import BCVRate
 from app.database.models.binance_sql_model import BinanceRate
 from app.schemas.bcv_response_schemas import BCVCurrencyResponse
 from app.schemas.binance_response_schemas import BinanceResponse
+from app.schemas.history_response_schemas import BinanceHistoryItem, BinanceHistoryResponse, BCVHistoryItem, BCVHistoryResponse
 
 class HistoryDataController:
     """
@@ -77,9 +78,19 @@ class HistoryDataController:
         )
         self._commit_or_rollback(session, record)
 
-    def get_bcv_history(self, start_date=None, end_date=None, currency=None):
+    def get_bcv_history(
+            self, 
+            start_date: datetime = None, 
+            end_date: datetime =None, 
+            currency: str = None
+        ) -> BCVHistoryResponse:
         """
         Get all BCV rates history.
+
+        Args:
+            start_date (datetime, optional): Start date for the query.
+            end_date (datetime, optional): End date for the query.
+            currency (str, optional): Currency to filter the query (DOLAR or EURO).
         """
         session = SessionLocal()
         query = session.query(BCVRate)
@@ -91,11 +102,36 @@ class HistoryDataController:
             query = query.filter(BCVRate.date < end_date)
         results = query.all()
         session.close()
-        return {"history": results}
+        
+        results = [
+            BCVHistoryItem(
+                id=result.id,
+                currency=result.currency,
+                rate=result.rate,
+                date=result.date
+            )
+            for result in results
+        ]
 
-    def get_binance_history(self, start_date=None, end_date=None, fiat=None, asset=None, trade_type=None):
+        return BCVHistoryResponse(count=len(results), history=results)
+
+    def get_binance_history(
+            self, 
+            start_date: datetime = None, 
+            end_date: datetime = None, 
+            fiat: str = None, 
+            asset: str = None, 
+            trade_type: str = None
+        ) -> BinanceHistoryResponse:
         """
         Get all Binance rates history.
+
+        Args:
+            start_date (datetime, optional): Start date for the query.
+            end_date (datetime, optional): End date for the query.
+            fiat (str, optional): Fiat currency to filter the query.
+            asset (str, optional): Asset to filter the query (USDT by default).
+            trade_type (str, optional): Trade type to filter the query (actually only BUY works for now).
         """
         session = SessionLocal()
         query = session.query(BinanceRate)
@@ -111,4 +147,17 @@ class HistoryDataController:
             query = query.filter(BinanceRate.date < end_date)
         results = query.all()
         session.close()
-        return {"history": results}
+
+        results = [
+            BinanceHistoryItem(
+                id=result.id,
+                fiat=result.fiat,
+                asset=result.asset,
+                trade_type=result.trade_type,
+                average_price=result.average_price,
+                date=result.date
+            )
+            for result in results
+        ]
+
+        return BinanceHistoryResponse(count=len(results), history=results)

--- a/app/schemas/history_response_schemas.py
+++ b/app/schemas/history_response_schemas.py
@@ -8,7 +8,7 @@ class BCVHistoryItem(BaseModel):
 
     Attributes:
         id (int): Database ID of the record.
-        currency (str): Currency symbol (e.g., USD, EUR).
+        currency (str): Currency type (e.g., DOLAR, EURO).
         rate (float): Exchange rate value.
         date (datetime): Timestamp of the record.
     """
@@ -22,7 +22,7 @@ class BCVHistoryItem(BaseModel):
             "examples": [
                 {
                     "id": 1,
-                    "currency": "USD",
+                    "currency": "DOLAR",
                     "rate": 40.25,
                     "date": "2025-11-21T00:00:00"
                 }
@@ -69,24 +69,27 @@ class BCVHistoryResponse(BaseModel):
     Schema for a list of historical BCV records.
 
     Attributes:
+        count (int): Number of historical items.
         history (List[BCVHistoryItem]): List of historical items.
     """
+    count: int = 0
     history: List[BCVHistoryItem]
 
     model_config = ConfigDict(
         json_schema_extra={
             "examples": [
                 {
+                    "count": 2,
                     "history": [
                         {
                             "id": 1,
-                            "currency": "USD",
+                            "currency": "DOLAR",
                             "rate": 40.25,
                             "date": "2025-11-21T00:00:00"
                         },
                         {
                             "id": 2,
-                            "currency": "EUR",
+                            "currency": "EURO",
                             "rate": 42.50,
                             "date": "2025-11-21T00:00:00"
                         }
@@ -101,14 +104,17 @@ class BinanceHistoryResponse(BaseModel):
     Schema for a list of historical Binance records.
 
     Attributes:
+        count (int): Number of historical items.
         history (List[BinanceHistoryItem]): List of historical items.
     """
+    count: int = 0
     history: List[BinanceHistoryItem]
 
     model_config = ConfigDict(
         json_schema_extra={
             "examples": [
                 {
+                    "count": 2,
                     "history": [
                         {
                             "id": 10,

--- a/app/ui/static/js/app.js
+++ b/app/ui/static/js/app.js
@@ -246,7 +246,7 @@ class ExchangeRateApp {
 
             // Fetch both history data in parallel
             const [bcvResponse, binanceResponse] = await Promise.all([
-                fetch(`${this.apiBaseUrl}/history/bcv?start_date=${startDateStr}&end_date=${endDateStr}&currency=USD`),
+                fetch(`${this.apiBaseUrl}/history/bcv?start_date=${startDateStr}&end_date=${endDateStr}&currency=DOLAR`),
                 fetch(`${this.apiBaseUrl}/history/binance?start_date=${startDateStr}&end_date=${endDateStr}&fiat=VES&asset=USDT&trade_type=BUY`)
             ]);
             
@@ -309,7 +309,7 @@ class ExchangeRateApp {
             const endDateStr = endDate.toISOString().split('T')[0];
 
             const [bcvResponse, binanceResponse] = await Promise.all([
-                fetch(`${this.apiBaseUrl}/history/bcv?start_date=${startDateStr}&end_date=${endDateStr}&currency=USD`),
+                fetch(`${this.apiBaseUrl}/history/bcv?start_date=${startDateStr}&end_date=${endDateStr}&currency=DOLAR`),
                 fetch(`${this.apiBaseUrl}/history/binance?start_date=${startDateStr}&end_date=${endDateStr}&fiat=VES&asset=USDT&trade_type=BUY`)
             ]);
             
@@ -320,6 +320,9 @@ class ExchangeRateApp {
             const bcvData = await bcvResponse.json();
             const binanceData = await binanceResponse.json();
             
+            console.log('BCV Data:', bcvData);
+            console.log('Binance Data:', binanceData);
+
             // Create CSV content
             let csvContent = "Date,BCV_Rate,Binance_Rate\n";
             


### PR DESCRIPTION
En esta PR, corregimos el problema de que la API no devolvía correctamente la data histórica del BCV. Se comprobó que, efectivamente, el controlador guardaba las tasas de cambio del BCV, pero esta información no se estaba devolviendo correctamente cuando se hacía la petición. El controlador no solo no estaba devolviendo la información con el esquema correcto, sino que además, la documentación de los esquemas indicaba que el filtro era mediante símbolos de moneda (VES, USD, EUR. etc), cuando en la base de datos, se guarda tal cual indica el enum, que refleja el nombre completo de la moneda.

En resumen:

- Se corrige la documentación en los esquemas que espera la API. Se agrega un count que indica el tamaño de los registros recibidos.
- Se corrigió la petición del controlador, que devuelve correctamente el esquema.
- Se corrigió el script de JS, para que solicite la información de forma correcta y pueda graficar y exportar los datos históricos.