### PR TITLE
Centralización de peticiones a la API de Binance y al BCV

### DIFF
--- a/app/enums/currecies_enum.py
+++ b/app/enums/currecies_enum.py
@@ -3,7 +3,16 @@
 from enum import StrEnum
 
 class Currency(StrEnum):
-    """Enum for representing currencies."""
+    """
+    Enum for representing currencies.
+
+    Attributes:
+        DOLAR (str): Represents the US Dollar.
+        EURO (str): Represents the Euro.
+        YUAN (str): Represents the Yuan.
+        LIRA (str): Represents the Turkish Lira.
+        RUBLE (str): Represents the Russian Ruble.
+    """
     DOLAR = "dolar"
     EURO = "euro"
     YUAN = "yuan"
@@ -18,7 +27,12 @@ class Currency(StrEnum):
     
     @property
     def description(self) -> str:
-        """Returns a description of the currency."""
+        """
+        Returns a description of the currency.
+
+        Returns:
+            str: A string describing the currency.
+        """
         return {
             Currency.DOLAR: "Dólar estadounidense",
             Currency.EURO: "Euro",

--- a/app/enums/webhook_priority_enum.py
+++ b/app/enums/webhook_priority_enum.py
@@ -3,6 +3,13 @@ from enum import Enum
 class WebhookPriority(Enum):
     """
     Enum for NTFY priority levels.
+
+    Attributes:
+        max (str): Represents the maximum priority.
+        high (str): Represents the high priority.
+        default (str): Represents the default priority.
+        low (str): Represents the low priority.
+        min (str): Represents the minimum priority.
     """
     max = 'max'
     high = 'high'

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,0 +1,2 @@
+from app.errors.base_error import DolarVzlaError
+from app.errors.app_errors import BCVConnectionError, BinanceConnectionError

--- a/app/errors/app_errors.py
+++ b/app/errors/app_errors.py
@@ -1,0 +1,11 @@
+from app.errors.base_error import DolarVzlaError
+
+class BCVConnectionError(DolarVzlaError):
+    """Error raised when there is a connection issue with the BCV website."""
+    def __init__(self, message: str = "Error connecting to the BCV website."):
+        super().__init__(message)
+
+class BinanceConnectionError(DolarVzlaError):
+    """Error raised when there is a connection issue with the Binance P2P API."""
+    def __init__(self, message: str = "Error connecting to the Binance P2P API."):
+        super().__init__(message)

--- a/app/errors/base_error.py
+++ b/app/errors/base_error.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict, Optional
+
+class DolarVzlaError(Exception):
+    """Base class for errors and exceptions."""
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.message = message
+        self.details = details or {}

--- a/app/scheduler/dolar_scheduler.py
+++ b/app/scheduler/dolar_scheduler.py
@@ -12,6 +12,9 @@ from app.enums import WebhookPriority, Currency
 
 class DolarScheduler():
     def __init__(self):
+        """
+        Initialize the DolarScheduler. This scheduler is responsible for periodically fetching exchange rates from BCV and Binance, saving them to the database, and sending notifications about updates or errors.
+        """
         self.controller = HistoryDataController()
         self.bcv = BCVScraper()
         self.binance = BinanceP2P()
@@ -39,9 +42,15 @@ class DolarScheduler():
         )
         self.notifier.emit(payload)
 
-    def save_bcv_rates(self):
+    def save_bcv_rates(self) -> None:
         """
         Save BCV rates.
+
+        Returns:
+            None
+
+        Exception:
+            Logs error and sends alert if there is an issue fetching or saving BCV rates.
         """
         self.logger.info("Saving BCV rates...")
         try:
@@ -72,9 +81,15 @@ class DolarScheduler():
                 tags="warning,skull"
             )
 
-    def save_binance_rate(self):
+    def save_binance_rate(self) -> None:
         """
         Save Binance rates.
+
+        Returns:
+            None
+        
+        Exception:
+            Logs error and sends alert if there is an issue fetching or saving Binance rates.
         """
         self.logger.info("Saving Binance rates...")
         try:
@@ -104,18 +119,24 @@ class DolarScheduler():
                 tags="warning"
             )
 
-    def scheduler_jobs(self):
+    def scheduler_jobs(self) -> None:
         """
         Scheduler jobs.
+        
+        Returns:
+            None
         """
         self.scheduler.add_job(self.save_bcv_rates, "cron", hour=0, minute=0)
         self.scheduler.add_job(self.save_binance_rate, "cron", hour=6)
         self.scheduler.add_job(self.save_binance_rate, "cron", hour=13)
         self.scheduler.add_job(self.save_binance_rate, "cron", hour=18)
 
-    def start(self):
+    def start(self) -> None:
         """
         Start scheduler.
+        
+        Returns:
+            None
         """
         self.logger.info("Starting scheduler...")
         self.scheduler_jobs()

--- a/app/schemas/bcv_response_schemas.py
+++ b/app/schemas/bcv_response_schemas.py
@@ -8,7 +8,7 @@ class BCVCurrencyResponse(BaseModel):
     """
     Schema for the response from BCV for a single currency.
 
-    Keyword arguments:
+    Attributes:
         currency (Currency): Currency tracked by BCV.
         rate (Optional[float]): Rate of the currency.
         date (datetime): Date of the response.
@@ -32,6 +32,13 @@ class BCVCurrencyResponse(BaseModel):
 class BCVResponse(BaseModel):
     """
     Schema for the general response from BCV to all currencies.
+
+    Attributes:
+        dolar (Optional[BCVCurrencyResponse]): BCV dolar response.
+        euro (Optional[BCVCurrencyResponse]): BCV euro response.
+        yuan (Optional[BCVCurrencyResponse]): BCV yuan response.
+        lira (Optional[BCVCurrencyResponse]): BCV lira response.
+        rublo (Optional[BCVCurrencyResponse]): BCV rublo response.
     """
     dolar: Optional[BCVCurrencyResponse]
     euro: Optional[BCVCurrencyResponse]

--- a/app/schemas/binance_request_schema.py
+++ b/app/schemas/binance_request_schema.py
@@ -1,11 +1,11 @@
 from typing import List, Optional, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class BinanceRequest(BaseModel):
     """
     Schema for the request to Binance P2P.
 
-    Keyword arguments:
+    Attributes:
         fiat (str): Fiat currency.
         page (int): Page number.
         rows (int): Number of rows per page.
@@ -38,3 +38,26 @@ class BinanceRequest(BaseModel):
     classifies: List[str] = ["mass", "profession", "fiat_trade"]
     tradedWith: bool = False
     followed: bool = False
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "fiat": "VES",
+                    "tradeType": "SELL",
+                    "asset": "USDT",
+                    "countries": ["Venezuela"],
+                    "proMerchantAds": False,
+                    "shieldMerchantAds": False,
+                    "filterType": "tradable",
+                    "periods": [],
+                    "additionalKycVerifyFilter": 0,
+                    "publisherType": None,
+                    "payTypes": [],
+                    "classifies": ["mass", "profession", "fiat_trade"],
+                    "tradedWith": False,
+                    "followed": False
+                }
+            ]
+        }
+    )

--- a/app/schemas/dolar_response.py
+++ b/app/schemas/dolar_response.py
@@ -4,13 +4,12 @@ from pydantic import BaseModel, ConfigDict
 
 from app.schemas.bcv_response_schemas import BCVCurrencyResponse
 from app.schemas.binance_response_schemas import BinanceResponse
-from app.enums import Currency
 
 class DolarResponse(BaseModel):
     """
     Schema for dolar prices from BCV and Binance for Venezuela interest case.
 
-    Keyword arguments:
+    Attributes:
         bcv_dolar (Optional[BCVCurrencyResponse]): BCV dolar response.
         bcv_euro (Optional[BCVCurrencyResponse]): BCV euro response.
         binance_usdt_ves_buy (Optional[BinanceResponse]): Binance USDT/VES response at Buy trade type.

--- a/app/services/bcv_scrapper.py
+++ b/app/services/bcv_scrapper.py
@@ -1,12 +1,13 @@
 """BCV Scraper module."""
 
-import requests
 import logging
 from datetime import datetime
 from bs4 import BeautifulSoup
 from typing import Optional
+from requests import Session, RequestException
 
 from app.enums.currecies_enum import Currency
+from app.errors.app_errors import BCVConnectionError
 from app.schemas import BCVCurrencyResponse, BCVResponse
 
 class BCVScraper:
@@ -14,19 +15,36 @@ class BCVScraper:
 
     def __init__(self):
         self.url = "https://www.bcv.org.ve"
+        self.session = Session()
         self.logger = logging.getLogger(self.__class__.__name__)
         self._soup = self._get_soup()
 
     def _get_soup(self) -> Optional[BeautifulSoup]:
-        """Get and parse the HTML content from the BCV website."""
+        """
+        Get and parse the HTML content from the BCV website.
+        
+        Returns:
+            Optional[BeautifulSoup]: The parsed HTML content, or None if there was an error.
+        
+        Raises:
+            BCVConnectionError: If there was an error connecting to the BCV website.
+        """
         try:
-            response = requests.get(self.url, verify=False, timeout=15)
+            response = self.session.get(self.url, verify=False, timeout=15)
             response.raise_for_status()
             self.logger.info(f"Connected to {self.url}")
             return BeautifulSoup(response.text, "html.parser")
-        except requests.RequestException as e:
+        except RequestException as e:
             self.logger.error(f"Error connecting to {self.url}: {e}")
-            return None
+            raise BCVConnectionError(
+                details={"url": self.url, "error": str(e)}
+            )
+        except Exception as e:
+            self.logger.error(f"Unexpected error while connecting to {self.url}: {e}")
+            raise BCVConnectionError(
+                message="Unexpected error while connecting to the BCV website.",
+                details={"url": self.url, "error": str(e)}
+            )
 
     def _get_currency_raw(self, currency: Currency) -> Optional[str]:
         """

--- a/app/services/binance_p2p.py
+++ b/app/services/binance_p2p.py
@@ -72,6 +72,7 @@ class BinanceP2P:
 
         Args:
             data (dict): Response data.
+            fiat (Optional[str]): Fiat currency for logging purposes.
 
         Returns:
             List[float]: List of prices.
@@ -91,7 +92,7 @@ class BinanceP2P:
         Calculate the median price.
 
         Args:
-            prices (list): List of prices.
+            prices (Optional[List[float]]): List of prices.
 
         Returns:
             Dict[str, float]: Median and average price

--- a/app/services/binance_p2p.py
+++ b/app/services/binance_p2p.py
@@ -1,9 +1,12 @@
 """Binance P2P module."""
 import requests
 import logging
+from requests import Session
+from requests.exceptions import RequestException
 from statistics import median, mean
 from typing import List, Optional, Dict
 
+from app.errors import BinanceConnectionError
 from app.schemas import BinanceRequest, BinanceResponse
    
 class BinanceP2P:
@@ -12,6 +15,7 @@ class BinanceP2P:
     """
     def __init__(self):
         self.url = "https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search"
+        self.session = Session()
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def build_request(
@@ -55,16 +59,29 @@ class BinanceP2P:
 
         Returns:
             dict: Response data.
+        
+        Raises:
+            BinanceConnectionError: If there was an error connecting to Binance P2P.
         """
         body = req.model_dump()
         try:
             self.logger.debug("Request Binance P2P")
-            res = requests.post(self.url, json=body, headers={"accept": "application/json"})
+            res = self.session.post(self.url, json=body, headers={"Content-Type": "application/json"}, timeout=15)
+            res.raise_for_status()
+            self.logger.debug("Response Binance P2P")
             json_data = res.json()
             return json_data
-        except Exception as e:
+        except RequestException as e:
             self.logger.error(f"Error at Binance P2P request: {e}")
-            return None
+            raise BinanceConnectionError(
+                details={"error": str(e)}
+            )
+        except ValueError as e:
+            self.logger.error(f"Error parsing Binance P2P response: {e}")
+            raise BinanceConnectionError(
+                message="Error parsing Binance P2P response.",
+                details={"error": str(e)}
+            )
 
     def colect_prices(self, data: dict, fiat: Optional[str] = None) -> List[float]:
         """

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,6 +5,6 @@ setup_logging()
 
 if __name__ == "__main__":
     binance = BinanceP2P()
-    precios = binance.get_pair(fiat="BRL", asset="USDT", trade_type="BUY", rows=20)
-    print(precios)
+    precios = binance.get_pair(fiat="PEN", asset="USDT", trade_type="BUY", rows=20)
+    print(precios.model_dump_json(indent=7))
 

--- a/tests/test_bcv.py
+++ b/tests/test_bcv.py
@@ -7,14 +7,4 @@ if __name__ == "__main__":
     bcv = BCVScraper()
 
     dolar_response = bcv.get_all_exchange_rates()
-    dolar = dolar_response.dolar.rate
-    euro = dolar_response.euro.rate
-    yuan = dolar_response.yuan.rate
-    lira = dolar_response.lira.rate
-    rublo = dolar_response.rublo.rate
-
-    print(f"Dolar: {dolar}")
-    print(f"Euro: {euro}")
-    print(f"Yuan: {yuan}")
-    print(f"Lira: {lira}")
-    print(f"Rublo: {rublo}")
+    print(dolar_response.model_dump_json(indent=4))

--- a/tests/ves_usdt.py
+++ b/tests/ves_usdt.py
@@ -6,5 +6,5 @@ setup_logging()
 if __name__ == "__main__":
     binance = BinanceP2P()
     price = binance.get_usdt_ves_pair()
-    print(price)
+    print(price.model_dump_json(indent=4))
 


### PR DESCRIPTION
Antes se realizaba una petición a la API (y a la página del BCV) por cada petición desde la app, ahora se crea una única sesión tanto en el scraper del BCVcomo en el cliente de la API de Binance. De esta forma, pueden realizarse múltiples peticiones en una sola sesión, reduciendo la posibilidad de ser rechazado por los servicios externos.

- Se modificó el uso de requests en BCVScraper y en BinanceP2P. Se encapsula la petición en session.
- Se agregaron errores personalizados para captar los eventos de conectividad con los servicios externos.
- Se modificaron los archivos de tests para usar y mostrar la respuesta completa con pydantic.